### PR TITLE
fix stale helper exports for build plugins

### DIFF
--- a/packages/plugins/plugin-esbuild/package.json
+++ b/packages/plugins/plugin-esbuild/package.json
@@ -44,26 +44,6 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./helpers": {
-      "import": "./dist/helpers/index.mjs",
-      "require": "./dist/helpers/index.cjs"
-    },
-    "./helpers/bundle": {
-      "import": "./dist/helpers/bundle.mjs",
-      "require": "./dist/helpers/bundle.cjs"
-    },
-    "./helpers/resolve": {
-      "import": "./dist/helpers/resolve.mjs",
-      "require": "./dist/helpers/resolve.cjs"
-    },
-    "./helpers/resolve-options": {
-      "import": "./dist/helpers/resolve-options.mjs",
-      "require": "./dist/helpers/resolve-options.cjs"
-    },
-    "./helpers/unplugin": {
-      "import": "./dist/helpers/unplugin.mjs",
-      "require": "./dist/helpers/unplugin.cjs"
-    },
     "./types": {
       "import": "./dist/types/index.mjs",
       "require": "./dist/types/index.cjs"

--- a/packages/plugins/plugin-rolldown/package.json
+++ b/packages/plugins/plugin-rolldown/package.json
@@ -44,18 +44,6 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./helpers": {
-      "import": "./dist/helpers/index.mjs",
-      "require": "./dist/helpers/index.cjs"
-    },
-    "./helpers/resolve-options": {
-      "import": "./dist/helpers/resolve-options.mjs",
-      "require": "./dist/helpers/resolve-options.cjs"
-    },
-    "./helpers/unplugin": {
-      "import": "./dist/helpers/unplugin.mjs",
-      "require": "./dist/helpers/unplugin.cjs"
-    },
     "./types": {
       "import": "./dist/types/index.mjs",
       "require": "./dist/types/index.cjs"

--- a/packages/plugins/plugin-tsdown/package.json
+++ b/packages/plugins/plugin-tsdown/package.json
@@ -44,18 +44,6 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./helpers": {
-      "import": "./dist/helpers/index.mjs",
-      "require": "./dist/helpers/index.cjs"
-    },
-    "./helpers/resolve-options": {
-      "import": "./dist/helpers/resolve-options.mjs",
-      "require": "./dist/helpers/resolve-options.cjs"
-    },
-    "./helpers/unplugin": {
-      "import": "./dist/helpers/unplugin.mjs",
-      "require": "./dist/helpers/unplugin.cjs"
-    },
     "./types": {
       "import": "./dist/types/index.mjs",
       "require": "./dist/types/index.cjs"

--- a/packages/plugins/plugin-tsup/package.json
+++ b/packages/plugins/plugin-tsup/package.json
@@ -44,18 +44,6 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./helpers": {
-      "import": "./dist/helpers/index.mjs",
-      "require": "./dist/helpers/index.cjs"
-    },
-    "./helpers/resolve-options": {
-      "import": "./dist/helpers/resolve-options.mjs",
-      "require": "./dist/helpers/resolve-options.cjs"
-    },
-    "./helpers/unplugin": {
-      "import": "./dist/helpers/unplugin.mjs",
-      "require": "./dist/helpers/unplugin.cjs"
-    },
     "./types": {
       "import": "./dist/types/index.mjs",
       "require": "./dist/types/index.cjs"

--- a/packages/plugins/plugin-vite/package.json
+++ b/packages/plugins/plugin-vite/package.json
@@ -44,18 +44,6 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./helpers": {
-      "import": "./dist/helpers/index.mjs",
-      "require": "./dist/helpers/index.cjs"
-    },
-    "./helpers/resolve-options": {
-      "import": "./dist/helpers/resolve-options.mjs",
-      "require": "./dist/helpers/resolve-options.cjs"
-    },
-    "./helpers/unplugin": {
-      "import": "./dist/helpers/unplugin.mjs",
-      "require": "./dist/helpers/unplugin.cjs"
-    },
     "./types": {
       "import": "./dist/types/index.mjs",
       "require": "./dist/types/index.cjs"


### PR DESCRIPTION
## Summary

This removes stale helper subpath exports from the build plugin package manifests:

- `@powerlines/plugin-tsup`
- `@powerlines/plugin-vite`
- `@powerlines/plugin-tsdown`
- `@powerlines/plugin-esbuild`
- `@powerlines/plugin-rolldown`

Those package.json exports point at `dist/helpers/...` files that are not present in the published packages or in these package source trees, so consumers can resolve a helper subpath and then fail at runtime with `ERR_MODULE_NOT_FOUND`.

The root exports, `./types` exports, and `./package.json` exports are unchanged.

## Reproduction

For example, with the current published `@powerlines/plugin-tsup@0.12.596` package:

```sh
mkdir -p /tmp/powerlines-plugin-tsup-pack-repro/node_modules/@powerlines
cd /tmp/powerlines-plugin-tsup-pack-repro
npm pack --silent @powerlines/plugin-tsup@0.12.596
mkdir -p node_modules/@powerlines/plugin-tsup
tar -xzf powerlines-plugin-tsup-0.12.596.tgz -C node_modules/@powerlines/plugin-tsup --strip-components=1
node --input-type=module -e "console.log(await import.meta.resolve('@powerlines/plugin-tsup/helpers'))"
node --input-type=module -e "await import('@powerlines/plugin-tsup/helpers')"
```

`import.meta.resolve()` points to `dist/helpers/index.mjs`, but that file is not included in the package, so importing it fails.

## Validation

- Checked the changed package manifests no longer expose any `./helpers*` export keys.
- `git diff --check`
- `pnpm install --frozen-lockfile --ignore-scripts`

I also attempted to run the `plugin-tsup` Vitest entry directly, but the test process stops during setup before executing tests because the installed `@storm-software/tsup` package imports `@nx/js/src/utils/buildable-libs-utils` without the `.js` extension under this Node/ESM setup. This change is limited to package export metadata.
